### PR TITLE
Make quotes in package.json cross env compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "src/index.js",
   "scripts": {
     "test": "npm run build && ava -v",
-    "build": "rollup src/index.js --format umd --name '$' --file dist/index.js"
+    "build": "rollup src/index.js --format umd --name \"$\" --file dist/index.js"
   },
   "author": "argyleink",
   "keywords": [


### PR DESCRIPTION
Single quotes don't work in arguments list in npm scripts on Windows